### PR TITLE
Minor changes

### DIFF
--- a/dad-joke.el
+++ b/dad-joke.el
@@ -22,7 +22,7 @@
 
 (require 'url-vars)
 
-(defconst dad-joke-server-url "http://icanhazdadjoke.com/"
+(defconst dad-joke-server-url "https://icanhazdadjoke.com/"
   "URL for the dad joke server.")
 
 (defconst dad-joke-user-agent "dad-joke.el (https://github.com/davep/dad-joke.el)"

--- a/dad-joke.el
+++ b/dad-joke.el
@@ -46,11 +46,11 @@ If INSERT is non-nil the joke will be inserted into the current
 buffer rather than shown in the minibuffer."
   (interactive "P")
   (let ((joke (dad-joke-get)))
-    (if (and joke (not (zerop (length joke))))
-        (if insert
-            (insert joke)
-          (message joke))
-      (error "I didn't get the joke! :-("))))
+    (if (zerop (length joke))
+        (error "I didn't get the joke! :-(")
+      (if insert
+          (insert joke)
+        (message "%s" joke)))))
 
 (provide 'dad-joke)
 

--- a/dad-joke.el
+++ b/dad-joke.el
@@ -20,6 +20,8 @@
 
 ;;; Code:
 
+(require 'url-vars)
+
 (defconst dad-joke-server-url "http://icanhazdadjoke.com/"
   "URL for the dad joke server.")
 

--- a/dad-joke.el
+++ b/dad-joke.el
@@ -30,12 +30,13 @@
 
 (defun dad-joke-get ()
   "Acquire a dad joke from the dad joke server."
-  (with-current-buffer
-      (let ((url-mime-accept-string "text/plain")
-            (url-request-extra-headers `(("User-Agent" . ,dad-joke-user-agent))))
-        (url-retrieve-synchronously dad-joke-server-url t t))
-    (set-buffer-multibyte t)
-    (buffer-substring-no-properties (point) (point-max))))
+  (let* ((url-mime-accept-string "text/plain")
+         (url-user-agent dad-joke-user-agent)
+         (buffer (url-retrieve-synchronously dad-joke-server-url t t)))
+    (when buffer
+      (with-current-buffer buffer
+        (set-buffer-multibyte t)
+        (buffer-substring-no-properties (point) (point-max))))))
 
 ;;;###autoload
 (defun dad-joke (&optional insert)


### PR DESCRIPTION
I was facing an intermittent issue which I cannot reliably reproduce, which resulted in the full `text/html` content, rather than just the `text/plain` joke text, being retrieved. This in turn could cause `message` to choke on what I assume was being interpreted as a format string. After making a few changes in trying to track down the issue, I can no longer reproduce the issue. I recommend reviewing each commit in turn as the changes are pretty small.

Emacs version: `GNU Emacs 26.0.50 (build 1, x86_64-pc-linux-gnu, X toolkit, Xaw3d scroll bars) of 2017-06-24`