### PR TITLE
Use higher-level url.el retriever

### DIFF
--- a/dad-joke.el
+++ b/dad-joke.el
@@ -41,13 +41,10 @@
   "Acquire a dad joke from the dad joke server."
   (let* ((url-mime-accept-string "text/plain")
          (url-request-extra-headers `(("User-Agent" . ,dad-joke-user-agent)))
-         (buffer (url-retrieve-synchronously dad-joke-server-url t t)))
-    (when buffer
-      (with-current-buffer buffer
-        (set-buffer-multibyte t)
-        (setf (point) (point-min))
-        (when (search-forward-regexp "^$" nil t)
-          (buffer-substring-no-properties (1+ (point)) (point-max)))))))
+         (url-show-status nil))
+    (with-temp-buffer
+      (url-insert-file-contents dad-joke-server-url)
+      (buffer-string))))
 
 ;;;###autoload
 (defun dad-joke (&optional insert)


### PR DESCRIPTION
#### Disclaimer

* By using `url-insert-file-contents` instead of `url-retrieve-synchronously` directly, we forgo being able to specify the `SILENT` and `INHIBIT-COOKIES` arguments. Nevertheless, I believe the former can at least somewhat be emulated by disabling `url-show-status`, and AFAICT there are no cookies involved in using this dad joke server.
* I have successfully tested these changes on the following Emacsen:
  - `GNU Emacs 27.0.50 (build 1, x86_64-pc-linux-gnu, X toolkit, Xaw3d scroll bars) of 2017-09-19`
  - `GNU Emacs 25.2.1 (x86_64-pc-linux-gnu, X toolkit, Xaw3d scroll bars) of 2017-09-12, modified by Debian`
  - `GNU Emacs 24.5.1 (x86_64-pc-linux-gnu, X toolkit, Xaw3d scroll bars) of 2017-04-29 on trouble, modified by Debian`